### PR TITLE
Add some commands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
 	license=open("LICENSE").read(),
 	author="Geoffrey Lehée",
 	author_email="geoffrey@lehee.name",
-	url='https://github.com/alexzhan/pyhn/',
+	url='https://github.com/socketubs/pyhn/',
 	keywords="python hackernews hn",
 	packages = ['pyhn'],
 	scripts=['scripts/pyhn'],


### PR DESCRIPTION
I want to use 'ctrl+f' to go several next stories and 'ctrl+b' to go several prev stories.
But I found that it can't be accomplished,because urwid could not recognize them.(Ibash & mac book air)
So I mapped the two to 'f' and 'd'.
That is: use 'f' to go next  15 stories and 'd' to go prev 15 stories.
I alse mapped 'G' to go to the last story and 'g' to the first.
The detect_end function is based on the circumstances of showing only 60 top/newest stories and 30 best stories.
