### PR TITLE
Multiple keybindings to same key

### DIFF
--- a/pyhn/gui.py
+++ b/pyhn/gui.py
@@ -156,10 +156,6 @@ class HNGui(object):
         if input in ('q', 'Q'):
             raise urwid.ExitMainLoop()
         # LINKS
-        if input in self.bindings['open_story_link'].split(','):
-            self.open_webbrowser(self.listbox.get_focus()[0].url)
-        if input in self.bindings['show_story_link'].split(','):
-            self.set_footer(self.listbox.get_focus()[0].url)
         if input in self.bindings['open_comments_link'].split(','):
             if self.listbox.get_focus()[0].comments_url == -1:
                 self.set_footer('No comments')
@@ -170,6 +166,10 @@ class HNGui(object):
                 self.set_footer('No comments')
             else:
                 self.set_footer(self.listbox.get_focus()[0].comments_url)
+        if input in self.bindings['open_story_link'].split(','):
+            self.open_webbrowser(self.listbox.get_focus()[0].url)
+        if input in self.bindings['show_story_link'].split(','):
+            self.set_footer(self.listbox.get_focus()[0].url)
         if input in self.bindings['open_submitter_link'].split(','):
             if self.listbox.get_focus()[0].submitter_url == -1:
                 self.set_footer('Anonymous submitter')


### PR DESCRIPTION
Awesome project!

I like to open both the comments and the story simultaneously, so I tried mapping both actions to the same key. This didn't work, however, until I changed the `elif` keywords to `if`s.

Also, I reversed the order of the two so that the story opened last and therefore appeared in my browser as the active tab.
