### PR TITLE
Add utf-8 to python re.search

### DIFF
--- a/pyhn/hnapi.py
+++ b/pyhn/hnapi.py
@@ -185,9 +185,12 @@ class HackerNewsAPI:
         """
         Gets the published time ago
         """
-        p = re.compile(r'\d{1,} (minutes|minute|hours|hour|day|days) ago')
-        results = p.search(source)
-        return results.group()
+        p = re.compile(r'\d{1,}\s(minutes|minute|hours|hour|day|days)\sago', re.U)
+        results = p.search(source.decode('utf-8'))
+        if results:
+            return results.group()
+        else:
+            return None
 
     def get_hn_id(self, source):
         """

--- a/pyhn/hnapi.py
+++ b/pyhn/hnapi.py
@@ -185,7 +185,7 @@ class HackerNewsAPI:
         """
         Gets the published time ago
         """
-        p = re.compile(r'\d{1,}\s(minutes|minute|hours|hour|day|days)\sago', re.U)
+        p = re.compile(r'\d{1,}\s(minutes|minute|hours|hour|day|days)\sago', flags=re.U)
         results = p.search(source.decode('utf-8'))
         if results:
             return results.group()


### PR DESCRIPTION
#### Got an error below when run command pyhn:
```
File "build/bdist.macosx-10.11-intel/egg/pyhn/hnapi.py", line 353, in get_top_stories
File "build/bdist.macosx-10.11-intel/egg/pyhn/hnapi.py", line 260, in get_stories
File "build/bdist.macosx-10.11-intel/egg/pyhn/hnapi.py", line 190, in get_published_time
AttributeError: 'NoneType' object has no attribute 'group'
```
#### Seems code is here:
`def get_published_time(self, source):`

#### Only knows little of python, please correct me if I am wrong
- if nothing matches, `re.search` will return `None`, and `None` has no attribute `group`
- To avoid `None` matches in python regex, change this to `utf-8` mode, both source and regex pattern

##### BTW, I am happy with using this cool tool for a long time, thanks.